### PR TITLE
update tslint-xo to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-jike-node",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -367,9 +367,9 @@
       }
     },
     "tslint-xo": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/tslint-xo/-/tslint-xo-0.5.0.tgz",
-      "integrity": "sha512-wvgvzi3bDnTOCVe+mRyw2XPzhg6347WNiBqEbzexodYGbnoZXyfky8Z/u5d/GAvcJKF15bndUgGVv1ZyHehHXw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tslint-xo/-/tslint-xo-0.6.0.tgz",
+      "integrity": "sha512-aiOllR1kd//zQ7242Zb+z1/17nPXX8n76RY+yoLMhoUX670Ok3j3SFwqvx7KNZo7bmhVK7f/r0ZsXe+s/QXPFg==",
       "requires": {
         "tslint-consistent-codestyle": "1.11.0",
         "tslint-eslint-rules": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-jike-node",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "TSLint config for Jike Node.js",
   "license": "MIT",
   "repository": "tslint-jike-node",
@@ -21,7 +21,7 @@
     "tslint-config"
   ],
   "dependencies": {
-    "tslint-xo": "0.5.0"
+    "tslint-xo": "0.6.0"
   },
   "devDependencies": {
     "tslint": "5.9.1",


### PR DESCRIPTION
1. `no-stateless-class` is deprecated
2. other rule update see [here](https://github.com/xojs/tslint-xo/commits/master)